### PR TITLE
Adding windows support as a valid blender addon platform to BlendNet 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /cert.pem
 __pycache__
 BlendNet_cache
+/.vs

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 /cert.pem
 __pycache__
 BlendNet_cache
-/.vs

--- a/BlendNet/providers/gcp/__init__.py
+++ b/BlendNet/providers/gcp/__init__.py
@@ -6,6 +6,8 @@ Copyright 2020 Google LLC.
 SPDX-License-Identifier: Apache-2.0
 
 '''
+import pathlib
+import platform
 
 __all__ = [
     'Manager',
@@ -58,13 +60,12 @@ def setGoogleCloudSdk(path):
 
 def findGoogleCloudSdk():
     '''Will try to find the google cloud sdk home directory'''
-    import os
     import subprocess
     # windows doesn't use PATH to locate binary unless shell=True
-    if os.name == 'nt':
-       result = subprocess.run(['gcloud', 'info'], shell=True, stdout=subprocess.PIPE)
+    if platform.system() == 'Windows':
+        result = subprocess.run(['gcloud', 'info'], shell=True, stdout=subprocess.PIPE)
     else:
-       result =  subprocess.run(['gcloud', 'info'], stdout=subprocess.PIPE)
+        result =  subprocess.run(['gcloud', 'info'], stdout=subprocess.PIPE)
     if result.returncode != 0:
         return
     lines = result.stdout.decode('utf-8').split('\n')
@@ -554,7 +555,6 @@ def createBucket(bucket_name):
 
 def uploadFileToBucket(path, bucket_name, dest_path = None):
     '''Upload file to the bucket'''
-    import pathlib
     from googleapiclient.http import MediaIoBaseUpload
     storage = _getStorage()
 
@@ -563,7 +563,7 @@ def uploadFileToBucket(path, bucket_name, dest_path = None):
     }
     
     # if the plugin was called from a windows OS, we need to convert the path separators for gsutil
-    if os.name == 'nt':
+    if platform.system() == 'Windows':
         body['name'] = pathlib.PurePath(body['name']).as_posix()
 
     print('INFO: Uploading file to "gs://%s/%s"...' % (bucket_name, body['name']))
@@ -578,7 +578,6 @@ def uploadFileToBucket(path, bucket_name, dest_path = None):
 
 def uploadDataToBucket(data, bucket_name, dest_path):
     '''Upload file to the bucket'''
-    import pathlib
     from googleapiclient.http import MediaInMemoryUpload
     storage = _getStorage()
 
@@ -587,7 +586,7 @@ def uploadDataToBucket(data, bucket_name, dest_path):
     }
     
     # if the plugin was called from a windows OS, we need to convert the path separators for gsutil
-    if os.name == 'nt':
+    if platform.system() == 'Windows':
         body['name'] = pathlib.PurePath(body['name']).as_posix()
 
     print('INFO: Uploading data to "gs://%s/%s"...' % (bucket_name, body['name']))

--- a/BlendNet/providers/gcp/__init__.py
+++ b/BlendNet/providers/gcp/__init__.py
@@ -4,6 +4,7 @@ Dependencies: google cloud sdk installed and configured auth
 
 Copyright 2020 Google LLC.
 SPDX-License-Identifier: Apache-2.0
+
 '''
 
 __all__ = [

--- a/BlendNet/providers/gcp/__init__.py
+++ b/BlendNet/providers/gcp/__init__.py
@@ -1,6 +1,9 @@
 '''Google Cloud Platform
 Provide API access to allocate required resources in GCP
 Dependencies: google cloud sdk installed and configured auth
+
+Copyright 2020 Google LLC.
+SPDX-License-Identifier: Apache-2.0
 '''
 
 __all__ = [
@@ -54,8 +57,13 @@ def setGoogleCloudSdk(path):
 
 def findGoogleCloudSdk():
     '''Will try to find the google cloud sdk home directory'''
+    import os
     import subprocess
-    result = subprocess.run(['gcloud', 'info'], stdout=subprocess.PIPE)
+    # windows doesn't use PATH to locate binary unless shell=True
+    if os.name == 'nt':
+       result = subprocess.run(['gcloud', 'info'], shell=True, stdout=subprocess.PIPE)
+    else:
+       result =  subprocess.run(['gcloud', 'info'], stdout=subprocess.PIPE)
     if result.returncode != 0:
         return
     lines = result.stdout.decode('utf-8').split('\n')
@@ -545,12 +553,17 @@ def createBucket(bucket_name):
 
 def uploadFileToBucket(path, bucket_name, dest_path = None):
     '''Upload file to the bucket'''
+    import pathlib
     from googleapiclient.http import MediaIoBaseUpload
     storage = _getStorage()
 
     body = {
         'name': dest_path or path,
     }
+    
+    # if the plugin was called from a windows OS, we need to convert the path separators for gsutil
+    if os.name == 'nt':
+        body['name'] = pathlib.PurePath(body['name']).as_posix()
 
     print('INFO: Uploading file to "gs://%s/%s"...' % (bucket_name, body['name']))
     with open(path, 'rb') as f:
@@ -564,12 +577,17 @@ def uploadFileToBucket(path, bucket_name, dest_path = None):
 
 def uploadDataToBucket(data, bucket_name, dest_path):
     '''Upload file to the bucket'''
+    import pathlib
     from googleapiclient.http import MediaInMemoryUpload
     storage = _getStorage()
 
     body = {
         'name': dest_path,
     }
+    
+    # if the plugin was called from a windows OS, we need to convert the path separators for gsutil
+    if os.name == 'nt':
+        body['name'] = pathlib.PurePath(body['name']).as_posix()
 
     print('INFO: Uploading data to "gs://%s/%s"...' % (bucket_name, body['name']))
     # TODO: make sure file uploaded or there is an isssue

--- a/BlendNet/providers/gcp/__init__.py
+++ b/BlendNet/providers/gcp/__init__.py
@@ -1,10 +1,6 @@
 '''Google Cloud Platform
 Provide API access to allocate required resources in GCP
 Dependencies: google cloud sdk installed and configured auth
-
-Copyright 2020 Google LLC.
-SPDX-License-Identifier: Apache-2.0
-
 '''
 import pathlib
 import platform


### PR DESCRIPTION
Tested on Win 10.

1) updating discovery of the gcloud tool to use  "shell=True"
2) converting paths before gsutil uploads from "\" to "/" as file separators