### PR TITLE
BN-19 Added ability to choose the blender version for render

### DIFF
--- a/BlendNet/Manager.py
+++ b/BlendNet/Manager.py
@@ -115,6 +115,8 @@ class Manager(providers.Manager, TaskExecutorBase):
         name_template = self._cfg.agent_instance_prefix + '%04d'
         cfg = {
             'session_id': self._cfg.session_id,
+            'dist_url': self._cfg.dist_url,
+            'dist_checksum': self._cfg.dist_checksum,
             'bucket': self._cfg.bucket,
             'instance_type': self._cfg.agent_instance_type,
             'listen_host': self._cfg.agent_listen_host,

--- a/BlendNet/ManagerAgentWorker.py
+++ b/BlendNet/ManagerAgentWorker.py
@@ -238,9 +238,9 @@ class ManagerAgentWorker:
             providers.startInstance(self._name)
         elif self.state() == ManagerAgentState.DESTROYED:
             print('DEBUG: Creating a new agent instance "%s"' % self._name)
-            itype = self._cfg['instance_type']
             self._setState(ManagerAgentState.UNKNOWN)
-            providers.createInstanceAgent(itype, self._cfg['session_id'], self._name)
+            self._cfg['instance_name'] = self._name
+            providers.createInstanceAgent(self._cfg)
 
     def _waitAgent(self):
         '''Will wait for agent availability'''

--- a/BlendNet/TaskExecutorBase.py
+++ b/BlendNet/TaskExecutorBase.py
@@ -24,6 +24,16 @@ class TaskExecutorConfig(Config):
             'type': str,
             'default': 'test',
         },
+        'dist_url': {
+            'description': '''Blender distributive URL''',
+            'type': str,
+            'default': 'https://example.com/blender-test.tar.xz',
+        },
+        'dist_checksum': {
+            'description': '''Blender distributive checksum''',
+            'type': str,
+            'default': '',
+        },
         'bucket': {
             'description': '''Bucket name used to store things''',
             'type': str,

--- a/BlendNet/addon.py
+++ b/BlendNet/addon.py
@@ -85,6 +85,8 @@ def getConfig():
 
     cfg = {} # TODO: Move to ManagerConfig
     cfg['session_id'] = prefs.session_id
+    cfg['dist_url'] = prefs.blender_dist_url
+    cfg['dist_checksum'] = prefs.blender_dist_checksum
     cfg['bucket'] = providers.getBucketName(cfg['session_id'])
 
     cfg['listen_port'] = prefs.manager_port
@@ -368,7 +370,7 @@ def startManager(cfg = None):
 
     if not isManagerCreated():
         print('DEBUG: Creating manager instance')
-        providers.createInstanceManager(cfg['instance_type'], cfg['session_id'], cfg['instance_name'])
+        providers.createInstanceManager(cfg)
         print('DEBUG: Creating the required firewall rules')
         providers.createFirewall('blendnet-manager', cfg['listen_port'])
         # Not needed firewall for agent - manager is using internal agent ip

--- a/BlendNet/providers/__init__.py
+++ b/BlendNet/providers/__init__.py
@@ -99,11 +99,11 @@ def getManagerSizeDefault():
 def getAgentSizeDefault():
     return _execProviderFunc('getAgentSizeDefault', '')
 
-def createInstanceManager(instance_type, session_id, name):
-    return _execProviderFunc('createInstanceManager', '', instance_type, session_id, name)
+def createInstanceManager(cfg):
+    return _execProviderFunc('createInstanceManager', '', cfg)
 
-def createInstanceAgent(instance_type, session_id, name):
-    return _execProviderFunc('createInstanceAgent', '', instance_type, session_id, name)
+def createInstanceAgent(cfg):
+    return _execProviderFunc('createInstanceAgent', '', cfg)
 
 def startInstance(name):
     return _execProviderFunc('startInstance', '', name)


### PR DESCRIPTION
Now BlendNet addon settings have a way to choose the existing version (3 mirrors) of Blender:
* Dynamic getting of the existing (and future) versions
* Selecting the version currently used by used by default
* Way to alter the version to old one or newer one (which will switch to the filled custom url/checksum)
* Way to put completely custom url/checksum and use it
* Custom url will not be altered until user say so - or user can switch back to not custom by deselect the checkbox

Issues:
* For some reason embedded ssl is not working... So had to disable it - checksum is the most important protection for now.

fixes: #19 