### PR TITLE
BN-47 Added getting the logs from cloud nodes and fixed alot of small issues

### DIFF
--- a/BlendNet/ManagerClient.py
+++ b/BlendNet/ManagerClient.py
@@ -28,9 +28,9 @@ class ManagerClient(Client):
         '''Get the list of agents with info'''
         res = self._engine.get('resources')
         if not res:
-            return {'agents':{}}
+            return {'agents': {}}
         if not res.get('manager'):
-            return res
+            return {'agents': res.get('agents', {})}
 
         # Set the client ip if manager have not provided the addresses
         if not res['manager'].get('ip'):

--- a/BlendNet/providers/__init__.py
+++ b/BlendNet/providers/__init__.py
@@ -94,7 +94,12 @@ def uploadDataToBucket(data, bucket, dest_path):
 
 def getResources(session_id):
     '''Returns map of allocated resources - manager and agents'''
+    # Agents are stored with the name keys
     return _execProviderFunc('getResources', {'agents':{}}, session_id)
+
+def getNodeLog(instance_id):
+    '''Returns string with the node serial output log'''
+    return _execProviderFunc('getNodeLog', 'NOT IMPLEMENTED', instance_id)
 
 def getBucketName(session_id):
     return _execProviderFunc('getBucketName', None, session_id)

--- a/BlendNet/providers/local/Manager.py
+++ b/BlendNet/providers/local/Manager.py
@@ -54,18 +54,18 @@ class Manager(InstanceProvider):
     def agentCustomRemove(self, agent_name):
         '''Remove the existing custom agent worker'''
         with self._agents_pool_lock:
-            worker_id = -1
+            worker_index = -1
             for i, worker in enumerate(self._agents_pool):
                 if worker.name() != agent_name:
                     continue
                 if worker.busy():
                     return False
-                worker_id = i
+                worker_index = i
 
-            if worker_id >= 0:
+            if worker_index >= 0:
                 self._cfg.agents_max -= 1
-                self._agents_pool[worker_id].stop()
-                del self._agents_pool[worker_id]
+                self._agents_pool[worker_index].stop()
+                del self._agents_pool[worker_index]
                 del LOCAL_RESOURCES['agents'][agent_name]
                 return True
 


### PR DESCRIPTION
* Added ability to get the logs from the cloud nodes
* Added button to destroy agents even on cloud providers
* Unpacking of blender now not so verbose - just prints a number of unpacked bytes
* Moved getResources back to agent names as keys
* Reorganized manager getResources to show not created agents
* Fixed a couple of issues with provisioning

related: #47 