### PR TITLE
BN-33 Adding composing support

### DIFF
--- a/BlendNet/Agent.py
+++ b/BlendNet/Agent.py
@@ -25,8 +25,9 @@ class AgentConfig(TaskExecutorConfig):
 
         super().__init__(parent, init)
 
-class Agent(providers.Agent, TaskExecutorBase):
+class Agent(TaskExecutorBase, providers.Agent):
     def __init__(self, conf):
         print('DEBUG: Creating Agent instance')
-        providers.Agent.__init__(self, conf)
         TaskExecutorBase.__init__(self, AgentTask, AgentConfig(self, conf))
+
+        providers.Agent.__init__(self)

--- a/BlendNet/Manager.py
+++ b/BlendNet/Manager.py
@@ -84,10 +84,9 @@ class ManagerConfig(TaskExecutorConfig):
 
         super().__init__(parent, init)
 
-class Manager(providers.Manager, TaskExecutorBase):
+class Manager(TaskExecutorBase, providers.Manager):
     def __init__(self, conf):
         print('DEBUG: Creating Manager instance')
-        providers.Manager.__init__(self, conf)
         TaskExecutorBase.__init__(self, ManagerTask, ManagerConfig(self, conf))
 
         self._agents_pool_lock = threading.Lock()
@@ -100,7 +99,10 @@ class Manager(providers.Manager, TaskExecutorBase):
         self._check_resources_timer = None
         self.resourcesGet(True)
 
+        providers.Manager.__init__(self)
+
         self.tasksLoad()
+        print('DEBUG: Created Manager instance')
 
     def setTerminating(self):
         '''Overrides setTerminating function to run save tasks'''
@@ -180,10 +182,9 @@ class Manager(providers.Manager, TaskExecutorBase):
         # Modify the provider resources to add more info for the Agents
         with self._resources_lock:
             out = {'manager': self._resources.get('manager', {}), 'agents': agents_pool}
-            for inst_id, info in self._resources.get('agents', {}).items():
-                # Find name with the specified ID
+            for inst_name, info in self._resources.get('agents', {}).items():
                 for name in out['agents']:
-                    if out['agents'][name].get('id') == inst_id:
+                    if name == inst_name:
                         out['agents'][name].update(info)
                         break
             return out

--- a/BlendNet/TaskBase.py
+++ b/BlendNet/TaskBase.py
@@ -130,6 +130,7 @@ class TaskBase(ABC):
             'start_time': self._start_time,
             'end_time': self._end_time,
             'state': self._state.name,
+            'frame': self._cfg.frame,
             'done': self._status['samples_done'] / self._cfg.samples,
         }
         if self._state_error_info:
@@ -144,7 +145,6 @@ class TaskBase(ABC):
                 'project': self._cfg.project,
                 'samples': self._cfg.samples,
                 'seed': self._cfg.seed,
-                'frame': self._cfg.frame,
             })
             out.update(self._status)
             return out

--- a/BlendNet/TaskExecutorBase.py
+++ b/BlendNet/TaskExecutorBase.py
@@ -120,21 +120,21 @@ class TaskExecutorBase(ABC):
 
     def tasksSave(self, tasks = []):
         '''Save in-memory tasks to disk'''
-        with self._tasks_lock:
-            if not tasks:
+        if not tasks:
+            with self._tasks_lock:
                 tasks = list(self._tasks.values())
 
-            print('DEBUG: Saving %s tasks to disk' % len(tasks))
+        print('DEBUG: Saving %s tasks to disk' % len(tasks))
 
-            os.makedirs(self._tasks_dir, 0o700, True)
+        os.makedirs(self._tasks_dir, 0o700, True)
 
-            for task in tasks:
-                try:
-                    filename = 'task-%s.json' % hashlib.sha1(task.name().encode('utf-8')).hexdigest()
-                    with open(os.path.join(self._tasks_dir, filename), 'w') as f:
-                        json.dump(task.snapshot(), f)
-                except Exception as e:
-                    print('ERROR: Unable to save task "%s" to disk: %s' % (task.name(), e))
+        for task in tasks:
+            try:
+                filename = 'task-%s.json' % hashlib.sha1(task.name().encode('utf-8')).hexdigest()
+                with open(os.path.join(self._tasks_dir, filename), 'w') as f:
+                    json.dump(task.snapshot(), f)
+            except Exception as e:
+                print('ERROR: Unable to save task "%s" to disk: %s' % (task.name(), e))
 
     def tasksLoad(self):
         '''Load tasks from disk'''
@@ -146,6 +146,7 @@ class TaskExecutorBase(ABC):
                 for entry in it:
                     if not (entry.is_file() and entry.name.endswith('.json')):
                         continue
+                    print('DEBUG: Loading task:', entry.name)
                     json_path = os.path.join(self._tasks_dir, entry.name)
                     try:
                         with open(json_path, 'r') as f:

--- a/BlendNet/addon.py
+++ b/BlendNet/addon.py
@@ -307,6 +307,7 @@ def updateManagerTasks():
         item = tasks_prop.add()
         item.name = tasks[name].get('name')
 
+    to_download = {}
     for i, item in enumerate(tasks_prop):
         task_name = item.name
         if task_name in to_rem:
@@ -324,14 +325,27 @@ def updateManagerTasks():
             done = task.get('done')
             item.done = ('%.2f%%' % (done*100)) if done > 0.01 else ''
 
-        if not item.received and task_name.startswith(getTaskProjectPrefix()) and task.get('state') == 'COMPLETED':
-            # TODO: make possible to use ### in the out path to save result using frame number
-            result = managerDownloadTaskResult(task_name, 'render')
-            if not result:
-                print('INFO: Downloading the final render for %s...' % task_name)
-                item.received = 'Downloading...'
-            else:
-                item.received = result
+        if task_name.startswith(getTaskProjectPrefix()) and task.get('state') == 'COMPLETED':
+            # Download only latest tasks frames, we don't need old ones here
+            key = str(task.get('frame'))
+            if key not in to_download:
+                to_download[key] = item
+            if to_download[key].create_time < item.create_time:
+                # Mark the previous as skipped
+                to_download[key].received = 'skipped'
+                to_download[key] = item
+            elif to_download[key].create_time > item.create_time:
+                item.received = 'skipped'
+
+    for item in to_download.values():
+        if item.received:
+            continue
+        result = managerDownloadTaskResult(task_name, 'compose')
+        if not result:
+            print('INFO: Downloading the final render for %s...' % task_name)
+            item.received = 'Downloading...'
+        else:
+            item.received = result
 
     manager_tasks_cache = tasks
 
@@ -480,34 +494,44 @@ def _managerDownloadTaskResultsWorker(task, result, file_path):
         ret = managerTaskResultDownload(task, result, file_path)
         if ret:
             break
-        print('WARN: Downloading of "%s" from task "%s" failed, repeating (%s)...' % (result, task, repeat))
+        print('WARN: Downloading of "%s" from task "%s" into "%s" failed, repeating (%s)...' % (
+            result, task, file_path, repeat
+        ))
         time.sleep(1.0)
     if ret:
-        print('DEBUG: Downloading of "%s" from task "%s" completed' % (result, task))
-        # Set the downloaded file path to the item received field
+        print('DEBUG: Downloading of "%s" from task "%s" into "%s" completed' % (result, task, file_path))
     else:
-        file_path = 'Download error: %s' % ret
+        print('ERROR: Download error: %s' % (ret,))
+    # Set the downloaded file path to the item received field
     for item in bpy.context.window_manager.blendnet.manager_tasks:
-        if item.name == task:
+        if item.name == task and result == 'compose' and item.received != 'skipped':
             item.received = file_path
 
-def managerDownloadTaskResult(task_name, result_to_download):
+def managerDownloadTaskResult(task_name, result_to_download, tempdir = None):
     '''Check the result existance and download if it's not matching the existing one'''
-    # TODO: make possible to use ### in the out path to save result using frame number
-    out_path = bpy.path.abspath(bpy.context.scene.render.filepath)
-    out_file = os.path.join(out_path, '%s.exr' % task_name)
+    out_dir = os.path.dirname(bpy.path.abspath(bpy.context.scene.render.filepath))
+    out_path = os.path.join(out_dir, result_to_download, task_name + '.exr')
+    if result_to_download == 'compose':
+        compose_filepath = managerTaskStatus(task_name).get('compose_filepath')
+        out_path = bpy.path.abspath(compose_filepath)
+    if not os.path.isabs(out_path):
+        out_path = os.path.abspath(out_path)
+    if tempdir:
+        # Download to temp folder just to preview the task result
+        out_path = os.path.join(tempdir, task_name + os.path.splitext(out_path)[-1])
+
     result = True
     checksum = None
     # Check the local file first - maybe it's the thing we need
-    if os.path.isfile(out_file):
+    if os.path.isfile(out_path):
         # Calculate sha1 to make sure it's the same file
         sha1_calc = hashlib.sha1()
-        with open(out_file, 'rb') as f:
+        with open(out_path, 'rb') as f:
             for chunk in iter(lambda: f.read(1048576), b''):
                 sha1_calc.update(chunk)
         checksum = sha1_calc.hexdigest()
         # If file and checksum are here - we need to get the actual task status to compare
-        result = managerTaskStatus(task_name).get('result', {}).get('render')
+        result = managerTaskStatus(task_name).get('result', {}).get(result_to_download)
 
     # If file is not working for us - than download
     if checksum != result:
@@ -519,10 +543,10 @@ def managerDownloadTaskResult(task_name, result_to_download):
                 _managerDownloadTaskResultsWorker,
             )
 
-        manager_task_download_workers.add(task_name, result_to_download, out_file)
+        manager_task_download_workers.add(task_name, result_to_download, out_path)
         manager_task_download_workers.start()
         return None
-    return out_file
+    return out_path
 
 def managerTaskConfig(task, conf):
     return ManagerClient(getManagerIP(), getConfig()).taskConfigPut(task, conf)

--- a/BlendNet/addon.py
+++ b/BlendNet/addon.py
@@ -341,10 +341,10 @@ def updateManagerTasks():
         if item.received:
             continue
         result = managerDownloadTaskResult(task_name, 'compose')
-        if not result:
+        if result == False:
             print('INFO: Downloading the final render for %s...' % task_name)
             item.received = 'Downloading...'
-        else:
+        elif result != None:
             item.received = result
 
     manager_tasks_cache = tasks
@@ -513,6 +513,9 @@ def managerDownloadTaskResult(task_name, result_to_download, tempdir = None):
     out_path = os.path.join(out_dir, result_to_download, task_name + '.exr')
     if result_to_download == 'compose':
         compose_filepath = managerTaskStatus(task_name).get('compose_filepath')
+        if not compose_filepath:
+            print('WARN: Unable to get the compose_filepath for task', task_name)
+            return None
         out_path = bpy.path.abspath(compose_filepath)
     if not os.path.isabs(out_path):
         out_path = os.path.abspath(out_path)
@@ -545,7 +548,7 @@ def managerDownloadTaskResult(task_name, result_to_download, tempdir = None):
 
         manager_task_download_workers.add(task_name, result_to_download, out_path)
         manager_task_download_workers.start()
-        return None
+        return False
     return out_path
 
 def managerTaskConfig(task, conf):

--- a/BlendNet/blend_file.py
+++ b/BlendNet/blend_file.py
@@ -61,7 +61,7 @@ def getCaches():
                 if not (localdir / cachedir).is_dir():
                     print('ERROR: Not a relative/not existing path of the cachedir '
                           '"%s" for object modifier %s --> %s' % (mod.domain_settings.cache_directory, o.name, mod.name))
-                    bad.add(mod.domain_settings.filepath)
+                    bad.add(cachedir)
                     continue
 
                 mod.domain_settings.cache_directory = '//' + cachedir.as_posix()
@@ -137,7 +137,7 @@ def getCaches():
                 for f in files_additional:
                     cpath = f.relative_to(localdir)
                     if cpath.as_posix() not in files:
-                        print('INFO: Found an additional fluid cache file to upload: %s' % (cpath.as_posix(),))
+                        print('INFO: Found an additional fluid cache file: %s' % (cpath.as_posix(),))
                         good.add(cpath.as_posix())
 
                 continue

--- a/BlendNet/providers/InstanceProvider.py
+++ b/BlendNet/providers/InstanceProvider.py
@@ -10,7 +10,7 @@ import threading # Locks
 from abc import ABC, abstractmethod
 
 class InstanceProvider(ABC):
-    def __init__(self, conf):
+    def __init__(self):
         self._terminating_lock = threading.Lock()
         self._terminating = None
 

--- a/BlendNet/providers/aws/Instance.py
+++ b/BlendNet/providers/aws/Instance.py
@@ -13,8 +13,8 @@ from . import _requestMetadata
 from .. import InstanceProvider
 
 class Instance(InstanceProvider):
-    def __init__(self, conf):
-        InstanceProvider.__init__(self, conf)
+    def __init__(self):
+        InstanceProvider.__init__(self)
 
         self._terminatingWatchersReset()
 

--- a/BlendNet/providers/gcp/Instance.py
+++ b/BlendNet/providers/gcp/Instance.py
@@ -13,8 +13,8 @@ from . import METADATA_URL, METADATA_HEADER
 from .. import InstanceProvider
 
 class Instance(InstanceProvider):
-    def __init__(self, conf):
-        InstanceProvider.__init__(self, conf)
+    def __init__(self):
+        InstanceProvider.__init__(self)
 
         self._terminatingWatchersReset()
 

--- a/BlendNet/script-compose.py
+++ b/BlendNet/script-compose.py
@@ -1,0 +1,72 @@
+#!/usr/bin/python3
+# -*- coding: UTF-8 -*-
+'''BlendNet Script Compose
+
+Description: Special script used by the Manager to compose result
+'''
+
+import signal # The other better ways are not working for subprocess...
+signal.signal(signal.SIGTERM, lambda s, f: print('WARN: Dodged TERM subprocess'))
+
+import os, sys, json
+sys.path.append(os.path.dirname(__file__))
+
+import disable_buffering
+
+# Read current task specification from json file
+task = None
+with open(sys.argv[-1], 'r') as f:
+    task = json.load(f)
+
+import bpy
+
+bpy.ops.wm.open_mainfile(filepath=task['project'])
+
+scene = bpy.context.scene
+
+# Enable compose to replace the regular render layers with prerender EXR
+scene.render.use_compositing = True
+scene.render.use_sequencer = False
+scene.use_nodes = True
+
+image_node = scene.node_tree.nodes.new(type='CompositorNodeImage')
+bpy.ops.image.open(filepath=task.get('render_file_path'), use_sequence_detection=False)
+image_node.image = bpy.data.images[bpy.path.basename(task.get('render_file_path'))]
+
+link_name_overrides = {}
+if image_node.image.type == 'MULTILAYER':
+    image_node.layer = 'View Layer'
+    link_name_overrides['Image'] = 'Combined'
+
+nodes_to_remove = []
+links_to_create = []
+for node in scene.node_tree.nodes:
+    if not isinstance(node, bpy.types.CompositorNodeRLayers) or node.scene != scene:
+        continue
+    nodes_to_remove.append(node)
+    print('INFO: Reconnecting %s links to render image' % (node,))
+    for link in scene.node_tree.links:
+        if link.from_node != node:
+            continue
+        link_name = link_name_overrides.get(link.from_socket.name, link.from_socket.name)
+        for output in image_node.outputs:
+            if output.name != link_name:
+                continue
+            links_to_create.append((output, link))
+            break
+
+for output, link in links_to_create:
+    print('INFO: Connecting "%s" output to %s.%s input' % (
+        output, link.to_node, link.to_socket
+    ))
+    scene.node_tree.links.new(output, link.to_socket)
+
+for node in nodes_to_remove:
+    print('INFO: Removing %s' % (node,))
+    scene.node_tree.nodes.remove(node)
+
+# Set the output file
+scene.render.filepath = '//' + os.path.join(task.get('result_dir'), bpy.path.basename(scene.render.filepath))
+bpy.ops.render.render(write_still=True)
+
+print('INFO: Compositing completed')

--- a/BlendNet/script-compose.py
+++ b/BlendNet/script-compose.py
@@ -12,6 +12,7 @@ import os, sys, json
 sys.path.append(os.path.dirname(__file__))
 
 import disable_buffering
+import blend_file
 
 # Read current task specification from json file
 task = None
@@ -20,18 +21,63 @@ with open(sys.argv[-1], 'r') as f:
 
 import bpy
 
-bpy.ops.wm.open_mainfile(filepath=task['project'])
+exitcode = 0
+
+print('INFO: Loading project file "%s"' % (task.get('project'),))
+bpy.ops.wm.open_mainfile(filepath=task.get('project'))
 
 scene = bpy.context.scene
 
-# Enable compose to replace the regular render layers with prerender EXR
+# Set frame if provided
+if 'frame' in task:
+    scene.frame_current = task['frame']
+
+print('INFO: Checking existance of the dependencies')
+blend_file.getDependencies()
+
+if scene.render.is_movie_format:
+    print('WARN: Unable to save still image to movie format, so use single-layer exr for compose')
+    exitcode = 1
+    scene.render.image_settings.file_format = 'OPEN_EXR'
+    scene.render.image_settings.color_mode = 'RGBA'
+    scene.render.image_settings.color_depth = '32'
+    scene.render.image_settings.exr_codec = 'ZIP'
+
+# Return the compose_filepath variable
+compose_filepath = scene.render.frame_path()
+if scene.render.filepath.startswith('//'):
+    # It's relative to blend project path
+    compose_filepath = bpy.path.relpath(compose_filepath)
+    # Sometimes it's not recognized properly
+    if not compose_filepath.startswith('//'):
+        compose_filepath = '//' + compose_filepath
+print('INFO: Compose filepath: %s' % (compose_filepath,))
+
+# Set the output file
+filename = bpy.path.basename(scene.render.frame_path())
+scene.render.filepath = os.path.join(task.get('result_dir'), filename)
+os.makedirs(bpy.path.abspath(task.get('result_dir')), mode=0o750, exist_ok=True)
+
+bpy.ops.image.open(filepath=bpy.path.abspath(task.get('render_file_path')), use_sequence_detection=False)
+image = bpy.data.images[bpy.path.basename(task.get('render_file_path'))]
+
+# If compositing is disabled - just convert the file to the required format
+if not task.get('use_compositing_nodes'):
+    if scene.render.image_settings.file_format == 'OPEN_EXR_MULTILAYER':
+        print('WARN: Just move the render to compose due to blender bug T71087')
+        os.rename(bpy.path.abspath(task.get('render_file_path')), bpy.path.abspath(scene.render.frame_path()))
+        sys.exit(1)
+
+    # Save the loaded image as render to convert
+    image.save_render(bpy.path.abspath(scene.render.frame_path()))
+
+# Enable compose to replace the regular render layers node with prerendered EXR image
 scene.render.use_compositing = True
 scene.render.use_sequencer = False
 scene.use_nodes = True
 
 image_node = scene.node_tree.nodes.new(type='CompositorNodeImage')
-bpy.ops.image.open(filepath=task.get('render_file_path'), use_sequence_detection=False)
-image_node.image = bpy.data.images[bpy.path.basename(task.get('render_file_path'))]
+image_node.image = image
 
 link_name_overrides = {}
 if image_node.image.type == 'MULTILAYER':
@@ -40,6 +86,7 @@ if image_node.image.type == 'MULTILAYER':
 
 nodes_to_remove = []
 links_to_create = []
+# Find nodes, links and outpus
 for node in scene.node_tree.nodes:
     if not isinstance(node, bpy.types.CompositorNodeRLayers) or node.scene != scene:
         continue
@@ -55,18 +102,19 @@ for node in scene.node_tree.nodes:
             links_to_create.append((output, link))
             break
 
+# Relinking previous render layer node outputs to the rendered image
 for output, link in links_to_create:
     print('INFO: Connecting "%s" output to %s.%s input' % (
         output, link.to_node, link.to_socket
     ))
     scene.node_tree.links.new(output, link.to_socket)
 
+# Removing the nodes could potentially break the pipeline
 for node in nodes_to_remove:
     print('INFO: Removing %s' % (node,))
     scene.node_tree.nodes.remove(node)
 
-# Set the output file
-scene.render.filepath = '//' + os.path.join(task.get('result_dir'), bpy.path.basename(scene.render.filepath))
 bpy.ops.render.render(write_still=True)
 
 print('INFO: Compositing completed')
+sys.exit(exitcode)

--- a/BlendNet/script-merge.py
+++ b/BlendNet/script-merge.py
@@ -18,6 +18,8 @@ task = None
 with open(sys.argv[-1], 'r') as f:
     task = json.load(f)
 
+print('DEBUG: Merging results:', task.get('images'))
+
 import _cycles
 _cycles.merge(
     input = task.get('images', []),

--- a/BlendNet/script-render.py
+++ b/BlendNet/script-render.py
@@ -35,9 +35,7 @@ import threading # To run timer and flush render periodically
 
 import bpy
 
-eprint('INFO: Loading project file "%s"' % task['project'])
-bpy.ops.wm.open_mainfile(filepath=task['project'])
-
+eprint("INFO: Preparing rendering of:", bpy.data.filepath)
 scene = bpy.context.scene
 
 # Set some required variables
@@ -97,6 +95,7 @@ class Commands:
         scene.render.image_settings.color_mode = 'RGB'
         scene.render.image_settings.color_depth = '32'
         scene.render.image_settings.exr_codec = 'DWAA'
+        # Should not be executed on the last sample otherwise will stuck right here
         bpy.data.images['Render Result'].save_render('_preview.exr')
         scene.render.image_settings.file_format = 'OPEN_EXR_MULTILAYER'
         scene.render.image_settings.color_mode = 'RGBA'
@@ -145,5 +144,7 @@ eprint('INFO: Render process completed')
 
 # Render complete - saving the result image
 executeCommand('saveRender')
+# Save the final preview to update the user
+executeCommand('savePreview')
 
 eprint('INFO: Save render completed')

--- a/manager.py
+++ b/manager.py
@@ -6,6 +6,10 @@ Description: REST interface for Manager
 Run: /srv/blender/blender -b -noaudio -P /srv/blendnet/manager.py
 '''
 
+import signal
+import faulthandler
+faulthandler.register(signal.SIGUSR1)
+
 import os, sys
 sys.path.append(os.path.dirname(__file__))
 


### PR DESCRIPTION
Become a quite huge change after testing on clouds, which show inconsistency in the BlendNet logic:

* Added compositing support (for now executed on Manager will be moved to Agent by #65)
* Now engines (Manager & Agent) are init provider overrides after TaskExecutorBase to use its configs
* Added more debugging information
* Changed defaults for create workspace and run blender script - there is no defaults anymore, you need to provide data into.
* Run blender script now accepts the blend file to make sure it will be loaded before the script running (important on small systems)
* Fixed issue with saving the one-layer render (instead of multilayer exr) on small systems
* Improved the error reporting - now it's more clear for user
* Fixed issue with using instance id instead of name in the resources list on the Manager
* Added isstopped logic to the ManagerAgentWorker to properly remove it when the Manager instance will go down later
* Changed the Manager render merge policy - now it's executed once when all the samples for the task are prepared
* Fixed the error with not stopping the ERROR task on Manager (no way to run another task after error task)
* Slightly improved saving the tasks mechanims - it should not cause deadlocks anymore
* Added local provider saving the added agents
* Addon: It's downloading results in async mode
* Addon: It's saving the compose result in place of the frame, previews saved to temp folder and available only during preview and render (if requested) is saved to the render directory with name of task.

fixes: #33 