### PR TITLE
BN-93 Moved manual download to always use the current output dir

### DIFF
--- a/BlendNet/addon.py
+++ b/BlendNet/addon.py
@@ -496,21 +496,23 @@ def _managerDownloadTaskResultsWorker(task, result, file_path):
         if item.name == task and result == 'compose' and item.received != 'skipped':
             item.received = file_path
 
-def managerDownloadTaskResult(task_name, result_to_download, tempdir = None):
+def managerDownloadTaskResult(task_name, result_to_download, result_dir = None):
     '''Check the result existance and download if it's not matching the existing one'''
     out_dir = os.path.dirname(bpy.path.abspath(bpy.context.scene.render.filepath))
     out_path = os.path.join(out_dir, result_to_download, task_name + '.exr')
     if result_to_download == 'compose':
         compose_filepath = managerTaskStatus(task_name).get('compose_filepath')
         if not compose_filepath:
-            print('WARN: Unable to get the compose_filepath for task', task_name)
-            return None
+            print('WARN: Unable to get the compose_filepath for the task', task_name)
+            print('WARN: will be used the current project output settings')
+            p = bpy.context.scene.render.frame_path()
+            compose_filepath = os.path.join(os.path.dirname(p), task_name + os.path.splitext(p)[-1]))
         out_path = bpy.path.abspath(compose_filepath)
     if not os.path.isabs(out_path):
         out_path = os.path.abspath(out_path)
-    if tempdir:
-        # Download to temp folder just to preview the task result
-        out_path = os.path.join(tempdir, task_name + os.path.splitext(out_path)[-1])
+    if result_dir:
+        # Used for preview or in manual download
+        out_path = os.path.join(result_dir, task_name + os.path.splitext(out_path)[-1])
 
     result = True
     checksum = None

--- a/BlendNet/addon.py
+++ b/BlendNet/addon.py
@@ -506,7 +506,7 @@ def managerDownloadTaskResult(task_name, result_to_download, result_dir = None):
             print('WARN: Unable to get the compose_filepath for the task', task_name)
             print('WARN: will be used the current project output settings')
             p = bpy.context.scene.render.frame_path()
-            compose_filepath = os.path.join(os.path.dirname(p), task_name + os.path.splitext(p)[-1]))
+            compose_filepath = os.path.join(os.path.dirname(p), task_name + os.path.splitext(p)[-1])
         out_path = bpy.path.abspath(compose_filepath)
     if not os.path.isabs(out_path):
         out_path = os.path.abspath(out_path)

--- a/BlendNet/script-compose.py
+++ b/BlendNet/script-compose.py
@@ -44,16 +44,6 @@ if scene.render.is_movie_format:
     scene.render.image_settings.color_depth = '32'
     scene.render.image_settings.exr_codec = 'ZIP'
 
-# Return the compose_filepath variable
-compose_filepath = scene.render.frame_path()
-if scene.render.filepath.startswith('//'):
-    # It's relative to blend project path
-    compose_filepath = bpy.path.relpath(compose_filepath)
-    # Sometimes it's not recognized properly
-    if not compose_filepath.startswith('//'):
-        compose_filepath = '//' + compose_filepath
-print('INFO: Compose filepath: %s' % (compose_filepath,))
-
 # Set the output file
 filename = bpy.path.basename(scene.render.frame_path())
 scene.render.filepath = os.path.abspath(os.path.join(task.get('result_dir'), filename))

--- a/__init__.py
+++ b/__init__.py
@@ -987,7 +987,10 @@ class BlendNetTaskDownloadOperation(bpy.types.Operator):
         wm = context.window_manager
 
         task_name = wm.blendnet.manager_tasks[wm.blendnet.manager_tasks_idx].name
-        result = BlendNet.addon.managerDownloadTaskResult(task_name, self.result)
+        # If the result is downloaded manually - use the current project output directory
+        out_dir = os.path.dirname(bpy.path.abspath(bpy.context.scene.frame_path()))
+        dir_path = os.path.join(out_dir, self.result)
+        result = BlendNet.addon.managerDownloadTaskResult(task_name, self.result, dir_path)
         if result is None:
             self.report({'WARNING'}, 'Unable to download the final result for %s, please retry later ' % (task_name,))
             return {'CANCELLED'}

--- a/__init__.py
+++ b/__init__.py
@@ -669,11 +669,18 @@ class BlendNetRunTaskOperation(bpy.types.Operator):
         if scene.cycles.use_square_samples:
             samples *= samples
 
+        # Where the compose result will be stored on the Addon side
+        compose_filepath = scene.render.frame_path()
+        if scene.render.filepath.startswith('//'):
+            # It's relative to blend project path
+            compose_filepath = bpy.path.relpath(compose_filepath)
+
         cfg = {
             'samples': samples,
             'frame': scene.frame_current,
             'project': fname,
             'use_compositing_nodes': scene.render.use_compositing,
+            'compose_filepath': compose_filepath,
         }
 
         if not BlendNet.addon.managerTaskConfig(self._task_name, cfg):
@@ -988,7 +995,7 @@ class BlendNetTaskDownloadOperation(bpy.types.Operator):
 
         task_name = wm.blendnet.manager_tasks[wm.blendnet.manager_tasks_idx].name
         # If the result is downloaded manually - use the current project output directory
-        out_dir = os.path.dirname(bpy.path.abspath(bpy.context.scene.frame_path()))
+        out_dir = os.path.dirname(bpy.context.scene.render.frame_path())
         dir_path = os.path.join(out_dir, self.result)
         result = BlendNet.addon.managerDownloadTaskResult(task_name, self.result, dir_path)
         if result is None:


### PR DESCRIPTION
* Allows to download the compose result anyway
* Changes the logic of set the compose_path from Manager side to Addon side.

fixes: #93 