### PR TITLE
BN-115 Workaround for change render engine from the render thread blender >= 2.90

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1546,8 +1546,9 @@ class BlendNetRenderEngine(bpy.types.RenderEngine):
         prev_name = ''
         loaded_final_render = False
         temp_dir = tempfile.TemporaryDirectory(prefix='blendnet-preview_')
+        result = self.begin_result(0, 0, self.size_x, self.size_y)
         while rendering:
-            time.sleep(1.0)
+            time.sleep(0.1)
 
             if self.test_break():
                 # TODO: render cancelled
@@ -1560,8 +1561,6 @@ class BlendNetRenderEngine(bpy.types.RenderEngine):
 
             task_name = wm.blendnet.manager_tasks[wm.blendnet.manager_tasks_idx].name
             if task_name != prev_name:
-                result = self.begin_result(0, 0, self.size_x, self.size_y)
-                self.end_result(result)
                 self.update_result(result)
                 prev_name = task_name
                 loaded_final_render = False
@@ -1606,7 +1605,6 @@ class BlendNetRenderEngine(bpy.types.RenderEngine):
                     status['result']['preview'] = prev_status.get('result', {}).get('preview')
 
             if update_render:
-                result = self.begin_result(0, 0, self.size_x, self.size_y)
                 if os.path.isfile(update_render):
                     try:
                         result.layers[0].load_from_file(update_render)
@@ -1617,12 +1615,12 @@ class BlendNetRenderEngine(bpy.types.RenderEngine):
                         print('DEBUG: Loaded render result file:', update_render)
                 else:
                     print('ERROR: Unable to load not existing result file "%s"' % (update_render,))
-                self.end_result(result)
                 self.update_result(result)
 
             prev_status = status
 
             self.update_progress(status.get('samples_done')/status.get('samples', 1))
+        self.end_result(result)
 
 
 def initPreferences():


### PR DESCRIPTION
Simplifies the render (task preview) process and fixes a bug with blender crash on windows during the render engine change.

fixes: #115 