### PR TITLE
BN-160 Fixed issue with default layer name for Blender v3

### DIFF
--- a/BlendNet/script-compose.py
+++ b/BlendNet/script-compose.py
@@ -82,7 +82,11 @@ image_node.image = image
 
 link_name_overrides = {}
 if image_node.image.type == 'MULTILAYER':
-    image_node.layer = 'View Layer'
+    try:
+        image_node.layer = 'View Layer'
+    except:
+        # In Blender v3 the naming was changed
+        image_node.layer = 'ViewLayer'
     link_name_overrides['Image'] = 'Combined'
 
 nodes_to_remove = []


### PR DESCRIPTION
Uses the name of default layer without space - not perfect, but working for v3 blender.